### PR TITLE
Fix issue with chat members not being able to edit notifications and …

### DIFF
--- a/src/main/java/com/example/telegramdailybot/service/NotificationService.java
+++ b/src/main/java/com/example/telegramdailybot/service/NotificationService.java
@@ -58,8 +58,10 @@ public class NotificationService {
             int notificationIdToDelete = Integer.parseInt(line);
             Notification notification = findById(notificationIdToDelete).orElse(null);
 
-            if (notification != null && (chatService.isAdmin(userId) || userId == chatId)) {
-                deleteById(notificationIdToDelete);
+            if (notification != null) {
+                if (chatService.isAdmin(userId) || notification.getChatid() == chatId) {
+                    deleteById(notificationIdToDelete);
+                }
             }
         }
     }
@@ -86,15 +88,16 @@ public class NotificationService {
 
             Notification notificationCurrent = findById(id).orElse(null);
 
-            if (notificationCurrent != null && (chatService.isAdmin(userId) || chatId == userId)) {
-                notificationCurrent.setText(notificationUpdated.getText());
-                notificationCurrent.setDatetime(notificationUpdated.getDatetime());
-                notificationCurrent.setRepetition(notificationUpdated.getRepetition());
-                notificationCurrent.setDatetimexcluded(notificationUpdated.getDatetimexcluded());
-                // Save the notification to the database
-                save(notificationCurrent);
+            if (notificationCurrent != null) {
+                if (chatService.isAdmin(userId) || notificationCurrent.getChatid() == chatId) {
+                    notificationCurrent.setText(notificationUpdated.getText());
+                    notificationCurrent.setDatetime(notificationUpdated.getDatetime());
+                    notificationCurrent.setRepetition(notificationUpdated.getRepetition());
+                    notificationCurrent.setDatetimexcluded(notificationUpdated.getDatetimexcluded());
+                    // Save the notification to the database
+                    save(notificationCurrent);
+                }
             }
-
             return "Уведомление успешно отредактировано";
         } catch (NumberFormatException e) {
             return "Ошибка при парсинге ID. Пожалуйста, проверьте формат и попробуйте еще раз.";

--- a/src/main/java/com/example/telegramdailybot/service/UserService.java
+++ b/src/main/java/com/example/telegramdailybot/service/UserService.java
@@ -54,8 +54,10 @@ public class UserService {
             int userIdtoDelete = Integer.parseInt(line);
             User user = findById(userIdtoDelete).orElse(null);
 
-            if (user != null && (chatService.isAdmin(userId) || userId == chatId)) {
-                deleteById(userIdtoDelete);
+            if (user != null) {
+                if (chatService.isAdmin(userId) || user.getChatid() == chatId) {
+                    deleteById(userIdtoDelete);
+                }
             }
         }
     }
@@ -73,10 +75,12 @@ public class UserService {
 
                 User user = findById(id).orElse(null);
 
-                if (user != null && (chatService.isAdmin(userId) || userId == chatId)) {
-                    user.setName(name);
-                    user.setUsername(username);
-                    save(user);
+                if (user != null) {
+                    if (chatService.isAdmin(userId) || user.getChatid() == chatId) {
+                        user.setName(name);
+                        user.setUsername(username);
+                        save(user);
+                    }
                 }
             }
         }


### PR DESCRIPTION
…users.

Previously, only admins had the ability to edit notifications and users, but this commit addresses a bug where chat members were unable to access these features. Now, all chat members should have the proper permissions to edit notifications and users.