### PR TITLE
Extend 'text' column length in Notification entity

### DIFF
--- a/src/main/java/com/example/telegramdailybot/model/Notification.java
+++ b/src/main/java/com/example/telegramdailybot/model/Notification.java
@@ -16,6 +16,7 @@ public class Notification {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
+    @Column(name = "text", length = 2000)
     private String text;
 
     @Column(name = "datetime")

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -49,7 +49,7 @@ CREATE SEQUENCE public.notifications_id_seq
 
 CREATE TABLE public.notifications (
     id integer DEFAULT nextval('public.notifications_id_seq'::regclass) NOT NULL,
-    text character varying(255) NOT NULL,
+    text character varying(2000) NOT NULL,
     datetime timestamp(6) with time zone NOT NULL,
     datetimexcluded jsonb,
     chatid bigint,


### PR DESCRIPTION
The length of the 'text' column in the Notification entity has been extended from 255 to 2000 characters to accommodate longer notifications. The Hibernate configuration has also been checked to ensure it does not overwrite this change on application start.